### PR TITLE
Add PQclear().

### DIFF
--- a/pg_keeper.c
+++ b/pg_keeper.c
@@ -327,10 +327,14 @@ execSQL(const char *conninfo, const char *sql)
 		ereport(LOG,
 				(errmsg("could not get tuple from server : \"%s\"",
 					conninfo)));
-
+		
+                PQclear(res); /* add */
+		
 		PQfinish(con);
 		return false;
 	}
+
+	PQclear(res); /* add */	
 
 	/* Primary server is alive now */
 	PQfinish(con);


### PR DESCRIPTION
CentOS Linux release 7.5.1804 (Core)
postgresql10-server-10.5-1PGDG.rhel7.x86_64

上記環境でしか確認していないのですが
standby 側のみ pg_keeper が memory leak していました。