### PR TITLE
Support PostgreSQL 11 or later

### DIFF
--- a/pg_keeper.c
+++ b/pg_keeper.c
@@ -243,7 +243,11 @@ KeeperMain(Datum main_arg)
 	BackgroundWorkerUnblockSignals();
 
 	/* Connect to our database */
+#if PG_VERSION_NUM >= 110000
+	BackgroundWorkerInitializeConnection("postgres", NULL, 0);
+#else
 	BackgroundWorkerInitializeConnection("postgres", NULL);
+#endif
 
 exec:
 


### PR DESCRIPTION
Pass flags param to BackgroundWorkerInitializeConnection
for PostgreSQL 11 or later.

Here is the commit that adds the "flags" parameter to
BackgroundWorkerInitializeConnection in PostgreSQL.

https://github.com/postgres/postgres/commit/eed1ce72e1593d3e8b7461d7744808d4d6bf402b